### PR TITLE
Add support for crypto currencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ after_success:
   - "pip install python-coveralls"
   - "coveralls"
 deploy:
+  skip_cleanup: true
   provider: pypi
   user: lockefox
   password:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.6-dev" # 3.6 development branch
-  - "3.7-dev" # 3.7 development branch
+#  - "3.7-dev" # 3.7 development branch
 install: 
   - "pip install semantic_version"
   - "pip install ."

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include prosper/datareader/version.txt

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,6 @@ Supported Feeds
 
 - Ticker Info: get info about coin<->currency conversion metadata
 - Price Quote: get latest OHLC data for given coin 
-- Price History: get history of coin price 
 - Order Book: view current orders
 
 .. _pandas-datareader: https://pandas-datareader.readthedocs.io/en/latest/index.html

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,16 @@ Supported Feeds
 - Market News Feed: Google
 - Price Quote: Robinhood
 
+**Coins**: helper libraries for fetching info on crypto currencies (via `hitBTC`_)
+
+- Ticker Info: get info about coin<->currency conversion metadata
+- Price Quote: get latest OHLC data for given coin 
+- Price History: get history of coin price 
+- Order Book: view current orders
+
 .. _pandas-datareader: https://pandas-datareader.readthedocs.io/en/latest/index.html
 .. _vader_sentiment: http://www.nltk.org/api/nltk.sentiment.html#module-nltk.sentiment.vader
+.. _hitBTC: https://hitbtc.com
 
 .. |Show Logo| image:: http://dl.eveprosper.com/podcast/logo-colour-17_sm2.png
    :target: http://eveprosper.com

--- a/docs/coins_help.rst
+++ b/docs/coins_help.rst
@@ -1,14 +1,49 @@
-=========================
-prosper.datareader.stocks
-=========================
+========================
+prosper.datareader.coins
+========================
 
-Meant as an extension of `pandas-datareader`_, ``prosper.datareader.stocks`` provides utilities for collecting news and quotes from other sources.
+Meant as an extension of `pandas-datareader`_, ``prosper.datareader.coins`` provides the ability to fetch and parse data pertaining to crypto currencies.
 
 ``prosper.datareader.coins`` relies on services from `hitBTC`_.
 
 Info
 ====
 
-General metadata and feed testing tools
+General metadata and feed testing tools.
 
-## TODO ##
+**NOTE**: will implement caching layer for info, since this data should only refresh daily
+
+get_symbol()
+------------
+
+    ``symbol_name = coins.info.get_symbol('COIN_TIKER', 'CONVERT_TICKER')``
+
+Price of a crypto currency is measured in relation to other currencies a la FOREX.  `hitBTC`_ requires a smash-cut version of coin + currency.
+
+Examples:
+
++------+----------+--------+
+| Coin | Currency | Ticker |
++======+==========+========+
+| BTC  | USD      | BTCUSD |
++------+----------+--------+
+| ETH  | EUR      | ETHEUR |
++------+----------+--------+
+| ETH  | BTC      | ETHBTC |
++------+----------+--------+
+
+Expected supported currencies:
+
+- ``USD``
+- ``EUR``
+- ``ETH``
+- ``BTC``
+
+For more info, try ``info.supported_currencies()`` for a current list
+
+get_ticker_info()
+-----------------
+
+    ``ticker_info = coins.info.get_ticker_info('TICKER')``
+
+If working backwards from a ticker, this function returns the original `hitBTC symbols`_ data.  

--- a/docs/coins_help.rst
+++ b/docs/coins_help.rst
@@ -47,3 +47,7 @@ get_ticker_info()
     ``ticker_info = coins.info.get_ticker_info('TICKER')``
 
 If working backwards from a ticker, this function returns the original `hitBTC symbols`_ data.  
+
+.. _pandas-datareader: https://pandas-datareader.readthedocs.io/en/latest/index.html
+.. _hitBTC: https://hitbtc.com/
+.. _hitBTC symbols: https://hitbtc.com/api#symbols

--- a/docs/coins_help.rst
+++ b/docs/coins_help.rst
@@ -1,0 +1,14 @@
+=========================
+prosper.datareader.stocks
+=========================
+
+Meant as an extension of `pandas-datareader`_, ``prosper.datareader.stocks`` provides utilities for collecting news and quotes from other sources.
+
+``prosper.datareader.coins`` relies on services from `hitBTC`_.
+
+Info
+====
+
+General metadata and feed testing tools
+
+## TODO ##

--- a/docs/coins_help.rst
+++ b/docs/coins_help.rst
@@ -48,6 +48,25 @@ get_ticker_info()
 
 If working backwards from a ticker, this function returns the original `hitBTC symbols`_ data.  
 
+Prices
+======
+
+get_quote_hitbtc()
+------------------
+
+    ``quote_df = coins.prices.get_quote_hitbtc(['BTC', 'ETH'])``
+
+Get a peek at the current price and trend of your favorite crypto currency.  This feed helps get OHLC data as well as mimic `pandas-datareader`_ quote behavior with keys like ``pct_change``.
+
+get_orderbook_hitbtc()
+----------------------
+
+    ``orderbook = coins.prices.get_orderbook_hitbtc('BTC', 'asks')``
+
+When you absolutely, positively, need all the data... go to the orderbook.  This supports ``asks`` and ``bids`` for lookup.
+
+## TODO: add ``both`` behavior
+
 .. _pandas-datareader: https://pandas-datareader.readthedocs.io/en/latest/index.html
 .. _hitBTC: https://hitbtc.com/
 .. _hitBTC symbols: https://hitbtc.com/api#symbols

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Supported Feeds
 
 * `Utils`_: General utilities for additional insights
 * `Stocks`_: Parse IRL stock quote data
-
+* `Coins`_: Data utilities for cryptocoin price quotes
 
 Index
 =====
@@ -33,9 +33,10 @@ Index
    :caption: Contents:
 
    getting_started.rst
-   utils_help.rst
    stocks_help.rst
-
+   coins_help.rst
+   utils_help.rst
+   
 Indices and tables
 ==================
 
@@ -47,6 +48,7 @@ Indices and tables
 .. _pandas-datareader: https://pandas-datareader.readthedocs.io/en/latest/index.html
 .. _Stocks: stocks_help.html
 .. _Utils: utils_help.html
+.. _Coins: coins_help.html
 
 .. |Build Status| image:: https://travis-ci.org/EVEprosper/ProsperDatareader.svg?branch=master
    :target: https://travis-ci.org/EVEprosper/ProsperDatareader

--- a/docs/source/datareader.coins.rst
+++ b/docs/source/datareader.coins.rst
@@ -12,6 +12,14 @@ datareader\.coins\.info module
     :undoc-members:
     :show-inheritance:
 
+datareader\.coins\.prices module
+--------------------------------
+
+.. automodule:: datareader.coins.prices
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/docs/source/datareader.coins.rst
+++ b/docs/source/datareader.coins.rst
@@ -1,0 +1,22 @@
+datareader\.coins package
+=========================
+
+Submodules
+----------
+
+datareader\.coins\.info module
+------------------------------
+
+.. automodule:: datareader.coins.info
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: datareader.coins
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/datareader.rst
+++ b/docs/source/datareader.rst
@@ -6,6 +6,7 @@ Subpackages
 
 .. toctree::
 
+    datareader.coins
     datareader.stocks
 
 Submodules

--- a/prosper/datareader/_version.py
+++ b/prosper/datareader/_version.py
@@ -18,11 +18,15 @@ def get_version():
 
     """
     if not INSTALLED:
-        warnings.warn(
-            'Unable to resolve package version until installed',
-            UserWarning
-        )
-        return '0.0.0'  #can't parse version without stuff installed
+        try:
+            with open('version.txt', 'r') as v_fh:
+                return v_fh.read()
+        except Exception:
+            warnings.warn(
+                'Unable to resolve package version until installed',
+                UserWarning
+            )
+            return '0.0.0'  #can't parse version without stuff installed
 
     return p_version.get_version(HERE)
 

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -1,0 +1,129 @@
+"""datareader.coins.info.py: tools for fetching stock news"""
+from datetime import datetime
+import itertools
+from os import path
+import warnings
+
+import requests
+import pandas as pd
+
+from prosper.datareader.config import LOGGER as G_LOGGER
+import prosper.datareader.exceptions as exceptions
+
+LOGGER = G_LOGGER
+HERE = path.abspath(path.dirname(__file__))
+
+SYMBOLS_URI = 'http://api.hitbtc.com/api/1/public/symbols'
+def get_supported_symbols(
+        uri=SYMBOLS_URI,
+        data_key='symbols'
+):
+    """fetch supported symbols from API
+
+    Note:
+        Supported by hitbtc
+        https://hitbtc.com/api#symbols
+
+    Args:
+        uri (str, optional): address for API
+        data_key (str, optional): data key name in JSON data
+
+    Returns:
+        (:obj:`list`): list of supported feeds
+
+    """
+    req = requests.get(uri)
+    req.raise_for_status()
+    data = req.json()
+
+    return data[data_key]
+
+
+def supported_commodity(
+        force_refresh=False,
+        logger=LOGGER
+):
+    """list supported symbols
+
+    Args:
+        force_refresh (bool, optional): ignore local cache and fetch directly from API
+        logger (:obj:`logging.logger`, optional): logging handle
+
+    Returns:
+        (:obj:`list`): list of supported crypto coins
+
+    """
+
+    #TODO: check cache
+    if force_refresh:
+        logger.info('--Fetching symbol list from API')
+        symbols_df = pd.DataFrame(get_supported_symbols())
+
+
+    commodities = list(symbols_df['commodity'].unique())
+
+    #TODO: save cache
+
+    return commodities
+
+def supported_currencies(
+        force_refresh=False,
+        logger=LOGGER
+):
+    """list supported currency conversions
+
+    Args:
+        force_refresh (bool, optional): ignore local cache and fetch directly from API
+        logger (:obj:`logging.logger`, optional): logging handle
+
+    Returns:
+        (:obj:`list`): list of supported currency conversions
+
+    """
+    #TODO: check cache
+    if force_refresh:
+        logger.info('--Fetching symbol list from API')
+        symbols_df = pd.DataFrame(get_supported_symbols())
+
+
+    currencies = list(symbols_df['currency'].unique())
+
+    #TODO: save cache
+
+    return currencies
+
+def get_symbol(
+        commodity_ticker,
+        currency_ticker,
+        force_refresh=False,
+        logger=LOGGER
+):
+    """get valid ticker to look up
+
+    Args:
+        commodity_ticker (str): short-name for crypto coin
+        currency_ticker (str): short-name for currency
+        force_refresh (bool, optional): ignore local cacne and fetch directly from API
+        logger (:obj:`logging.logger`, optional): logging handle
+
+    Returns:
+        (str): valid ticker for HITBTC
+
+    """
+    #TODO: check cache
+    if force_refresh:
+        logger.info('--Fetching symbol list from API')
+        symbols_df = pd.DataFrame(get_supported_symbols())
+
+    symbol = symbols_df.query(
+        'commodity==\'{commodity}\' & currency==\'{currency}\''.format(
+            commodity=commodity_ticker,
+            currency=currency_ticker
+        ))
+
+    if symbol.empty:
+        raise exceptions.SymbolNotSupported()
+
+    #TODO: update cache
+
+    return symbol['symbol'].iloc[0]

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -13,7 +13,7 @@ LOGGER = G_LOGGER
 HERE = path.abspath(path.dirname(__file__))
 
 __all__ = (
-    'get_symbol', 'get_ticker_info', 'supported_commodities', 'supported_currencies'
+    'get_symbol', 'get_ticker_info', 'supported_symbol_info'
 )
 
 SYMBOLS_URI = 'http://api.hitbtc.com/api/1/public/symbols'
@@ -62,7 +62,6 @@ def supported_symbol_info(
 def get_symbol(
         commodity_ticker,
         currency_ticker,
-        force_refresh=False,
         logger=LOGGER
 ):
     """get valid ticker to look up
@@ -70,17 +69,14 @@ def get_symbol(
     Args:
         commodity_ticker (str): short-name for crypto coin
         currency_ticker (str): short-name for currency
-        force_refresh (bool, optional): ignore local cacne and fetch directly from API
         logger (:obj:`logging.logger`, optional): logging handle
 
     Returns:
         (str): valid ticker for HITBTC
 
     """
-    #TODO: check cache
-    if force_refresh:
-        logger.info('--Fetching symbol list from API')
-        symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
+    logger.info('--Fetching symbol list from API')
+    symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
 
     symbol = symbols_df.query(
         'commodity==\'{commodity}\' & currency==\'{currency}\''.format(
@@ -91,13 +87,10 @@ def get_symbol(
     if symbol.empty:
         raise exceptions.SymbolNotSupported()
 
-    #TODO: update cache
-
     return symbol['symbol'].iloc[0]
 
 def get_ticker_info(
         ticker,
-        force_refresh=False,
         logger=LOGGER
 ):
     """reverse lookup, get more info about a requested ticker
@@ -111,15 +104,12 @@ def get_ticker_info(
         (:obj:`dict`): hitBTC info about requested ticker
 
     """
-    #TODO: check cache
-    if force_refresh:
-        logger.info('--Fetching symbol list from API')
-        data = get_supported_symbols_hitbtc()
+    logger.info('--Fetching symbol list from API')
+    data = get_supported_symbols_hitbtc()
 
     ## Skip pandas, vanilla list search ok here
     for ticker_info in data:
         if ticker_info['symbol'] == ticker.upper():
             return ticker_info
 
-    #TODO: update cache
     raise exceptions.TickerNotFound()

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -1,8 +1,7 @@
-"""datareader.coins.info.py: tools for fetching stock news"""
+"""datareader.coins.info.py: tools for fetching cryptocoin metadata"""
 from datetime import datetime
 import itertools
 from os import path
-import warnings
 
 import requests
 import pandas as pd
@@ -12,6 +11,10 @@ import prosper.datareader.exceptions as exceptions
 
 LOGGER = G_LOGGER
 HERE = path.abspath(path.dirname(__file__))
+
+__all__ = (
+    'get_symbol', 'get_ticker_info', 'supported_commodities', 'supported_currencies'
+)
 
 SYMBOLS_URI = 'http://api.hitbtc.com/api/1/public/symbols'
 def get_supported_symbols(

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -41,58 +41,23 @@ def get_supported_symbols_hitbtc(
 
     return data[data_key]
 
-def supported_commodities(
-        force_refresh=False,
-        logger=LOGGER
+def supported_symbol_info(
+        key_name
 ):
-    """list supported symbols
+    """find unique values for key_name in symbol feed
 
     Args:
-        force_refresh (bool, optional): ignore local cache and fetch directly from API
-        logger (:obj:`logging.logger`, optional): logging handle
+        key_name (str): name of key to search
 
     Returns:
-        (:obj:`list`): list of supported crypto coins
+        (:obj:`list`): list of unique values
 
     """
+    symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
 
-    #TODO: check cache
-    if force_refresh:
-        logger.info('--Fetching symbol list from API')
-        symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
+    unique_list = list(symbols_df[key_name].unique())
 
-
-    commodities = list(symbols_df['commodity'].unique())
-
-    #TODO: save cache
-
-    return commodities
-
-def supported_currencies(
-        force_refresh=False,
-        logger=LOGGER
-):
-    """list supported currency conversions
-
-    Args:
-        force_refresh (bool, optional): ignore local cache and fetch directly from API
-        logger (:obj:`logging.logger`, optional): logging handle
-
-    Returns:
-        (:obj:`list`): list of supported currency conversions
-
-    """
-    #TODO: check cache
-    if force_refresh:
-        logger.info('--Fetching symbol list from API')
-        symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
-
-
-    currencies = list(symbols_df['currency'].unique())
-
-    #TODO: save cache
-
-    return currencies
+    return unique_list
 
 def get_symbol(
         commodity_ticker,

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -39,7 +39,7 @@ def get_supported_symbols(
     return data[data_key]
 
 
-def supported_commodity(
+def supported_commodities(
         force_refresh=False,
         logger=LOGGER
 ):
@@ -117,8 +117,8 @@ def get_symbol(
 
     symbol = symbols_df.query(
         'commodity==\'{commodity}\' & currency==\'{currency}\''.format(
-            commodity=commodity_ticker,
-            currency=currency_ticker
+            commodity=commodity_ticker.upper(),
+            currency=currency_ticker.upper()
         ))
 
     if symbol.empty:

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -41,6 +41,8 @@ def get_supported_symbols_hitbtc(
 
     return data[data_key]
 
+################################################################################
+
 def supported_symbol_info(
         key_name
 ):

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -17,7 +17,7 @@ __all__ = (
 )
 
 SYMBOLS_URI = 'http://api.hitbtc.com/api/1/public/symbols'
-def get_supported_symbols(
+def get_supported_symbols_hitbtc(
         uri=SYMBOLS_URI,
         data_key='symbols'
 ):
@@ -41,7 +41,6 @@ def get_supported_symbols(
 
     return data[data_key]
 
-
 def supported_commodities(
         force_refresh=False,
         logger=LOGGER
@@ -60,7 +59,7 @@ def supported_commodities(
     #TODO: check cache
     if force_refresh:
         logger.info('--Fetching symbol list from API')
-        symbols_df = pd.DataFrame(get_supported_symbols())
+        symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
 
 
     commodities = list(symbols_df['commodity'].unique())
@@ -86,7 +85,7 @@ def supported_currencies(
     #TODO: check cache
     if force_refresh:
         logger.info('--Fetching symbol list from API')
-        symbols_df = pd.DataFrame(get_supported_symbols())
+        symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
 
 
     currencies = list(symbols_df['currency'].unique())
@@ -116,7 +115,7 @@ def get_symbol(
     #TODO: check cache
     if force_refresh:
         logger.info('--Fetching symbol list from API')
-        symbols_df = pd.DataFrame(get_supported_symbols())
+        symbols_df = pd.DataFrame(get_supported_symbols_hitbtc())
 
     symbol = symbols_df.query(
         'commodity==\'{commodity}\' & currency==\'{currency}\''.format(
@@ -150,7 +149,7 @@ def get_ticker_info(
     #TODO: check cache
     if force_refresh:
         logger.info('--Fetching symbol list from API')
-        data = get_supported_symbols()
+        data = get_supported_symbols_hitbtc()
 
     ## Skip pandas, vanilla list search ok here
     for ticker_info in data:

--- a/prosper/datareader/coins/info.py
+++ b/prosper/datareader/coins/info.py
@@ -127,3 +127,32 @@ def get_symbol(
     #TODO: update cache
 
     return symbol['symbol'].iloc[0]
+
+def get_ticker_info(
+        ticker,
+        force_refresh=False,
+        logger=LOGGER
+):
+    """reverse lookup, get more info about a requested ticker
+
+    Args:
+        ticker (str): info ticker for coin (ex: BTCUSD)
+        force_refresh (bool, optional): ignore local cacne and fetch directly from API
+        logger (:obj:`logging.logger`, optional): logging handle
+
+    Returns:
+        (:obj:`dict`): hitBTC info about requested ticker
+
+    """
+    #TODO: check cache
+    if force_refresh:
+        logger.info('--Fetching symbol list from API')
+        data = get_supported_symbols()
+
+    ## Skip pandas, vanilla list search ok here
+    for ticker_info in data:
+        if ticker_info['symbol'] == ticker.upper():
+            return ticker_info
+
+    #TODO: update cache
+    raise exceptions.TickerNotFound()

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -158,19 +158,20 @@ def get_quote_hitbtc(
 
     """
     logger.info('Generating quote for %s -- HitBTC', config._list_to_str(coin_list))
-    #singleton = False
-    #if isinstance(coin_list, str):
-    #    singleton = True
-    #    logger.info('--singleton mode')
+
+    logger.info('--validating coin_list')
+    ticker_list = coin_list_to_ticker_list(
+        coin_list,
+        currency=currency,
+        strict=True
+    )
 
     logger.info('--fetching ticker data')
     raw_quote = get_ticker_hitbtc('')
-
-    quote_df = df.DataFrame(raw_quote)
+    quote_df = pd.DataFrame(raw_quote)
 
     logger.info('--filtering ticker data')
+    quote_df = quote_df[quote_df['symbol'].isin(ticker_list)]
 
-
-
-
-
+    logger.debug(quote_df)
+    return quote_df

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -6,10 +6,11 @@ from enum import Enum
 import requests
 import pandas as pd
 
-from prosper.datareader.config import LOGGER as G_LOGGER
+import prosper.datareader.config as config
 import prosper.datareader.exceptions as exceptions
+import prosper.datareader.coins.info as info
 
-LOGGER = G_LOGGER
+LOGGER = config.LOGGER
 HERE = path.abspath(path.dirname(__file__))
 
 class OrderBook(Enum):
@@ -41,19 +42,35 @@ def _listify(
 
 def coin_list_to_ticker_list(
         coin_list,
-        currency='USD'
+        currency='USD',
+        strict=False
 ):
     """convert list of crypto currencies to HitBTC tickers
 
     Args:
         coin_list (str or :obj:`list`): list of coins to convert
         currency (str, optional): currency to FOREX against
+        strict (bool, optional): throw if unsupported ticker is requested
 
     Returns:
         (:obj:`list`): list of valid coins and tickers
 
     """
-    pass
+    valid_ticker_list = info.supported_symbol_info('symbol')
+
+    ticker_list = []
+    invalid_tickers = []
+    for coin in coin_list:
+        ticker = str(coin) + currency
+        if ticker not in valid_ticker_list:
+            invalid_tickers.append(ticker)
+
+        ticker_list.append(ticker)
+
+    if invalid_tickers and strict:
+        raise KeyError('Unsupported ticker requested: {}'.format(invalid_tickers))
+
+    return ticker_list
 
 COIN_TICKER_URI = 'http://api.hitbtc.com/api/1/public/{symbol}/ticker'
 def get_ticker_hitbtc(

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -11,3 +11,25 @@ import prosper.datareader.exceptions as exceptions
 
 LOGGER = G_LOGGER
 HERE = path.abspath(path.dirname(__file__))
+
+COIN_TICKER_URI = 'http://api.hitbtc.com/api/1/public/{ticker}/ticker'
+def get_ticker(
+        symbol,
+        uri=COIN_TICKER_URI
+):
+    """fetch quote for coin
+
+    Notes:
+        incurs a .format(ticker=symbol) call, be careful with overriding uri
+
+    Args:
+        symbol (str): name of coin-ticker to pull
+        uri (str, optional): resource link
+
+    Returns:
+        (:obj:`dict`): ticker data for desired coin
+
+    """
+    req = requests.get(uri.format(ticker=symbol))
+    req.raise_for_status()
+    return req.json()

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -1,0 +1,13 @@
+"""datareader.coins.prices.py: tools for fetching cryptocoin price data"""
+from datetime import datetime
+import itertools
+from os import path
+
+import requests
+import pandas as pd
+
+from prosper.datareader.config import LOGGER as G_LOGGER
+import prosper.datareader.exceptions as exceptions
+
+LOGGER = G_LOGGER
+HERE = path.abspath(path.dirname(__file__))

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -14,6 +14,8 @@ LOGGER = config.LOGGER
 HERE = path.abspath(path.dirname(__file__))
 
 __all__ = ('get_orderbook_hitbtc', 'get_quote_hitbtc')
+
+
 class OrderBook(Enum):
     """enumerator for handling order book info"""
     asks = 'asks'
@@ -93,15 +95,17 @@ def get_ticker_hitbtc(
     """
     full_uri = ''
     if not symbol:
+        ## fetching entire ticker list ##
         full_uri = uri.replace(r'{symbol}/', '')
     else:
         full_uri = uri.format(symbol=symbol)
 
     req = requests.get(full_uri)
     req.raise_for_status()
-
     data = req.json()
+
     if not symbol:
+        ## fetching entire ticker list ##
         data = _listify(data, 'symbol')
 
     return data
@@ -142,6 +146,8 @@ def get_order_book_hitbtc(
     data = req.json()
 
     return data #return both bids/asks for other steps to clean up later
+
+################################################################################
 
 def get_quote_hitbtc(
         coin_list,

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -39,6 +39,22 @@ def _listify(
 
     return listified_data
 
+def coin_list_to_ticker_list(
+        coin_list,
+        currency='USD'
+):
+    """convert list of crypto currencies to HitBTC tickers
+
+    Args:
+        coin_list (str or :obj:`list`): list of coins to convert
+        currency (str, optional): currency to FOREX against
+
+    Returns:
+        (:obj:`list`): list of valid coins and tickers
+
+    """
+    pass
+
 COIN_TICKER_URI = 'http://api.hitbtc.com/api/1/public/{symbol}/ticker'
 def get_ticker_hitbtc(
         symbol,
@@ -108,3 +124,36 @@ def get_order_book_hitbtc(
     data = req.json()
 
     return data #return both bids/asks for other steps to clean up later
+
+def get_quote_hitbtc(
+        coin_list,
+        currency='USD',
+        logger=LOGGER
+):
+    """fetch common summary data for crypto-coins
+
+    Args:
+        coin_list (:obj:`list`): list of tickers to look up
+        logger (:obj:`logging.logger`, optional): logging handle
+
+    Returns:
+        (:obj:`pandas.DataFrame`): coin info for the day, JSONable
+
+    """
+    logger.info('Generating quote for %s -- HitBTC', config._list_to_str(coin_list))
+    #singleton = False
+    #if isinstance(coin_list, str):
+    #    singleton = True
+    #    logger.info('--singleton mode')
+
+    logger.info('--fetching ticker data')
+    raw_quote = get_ticker_hitbtc('')
+
+    quote_df = df.DataFrame(raw_quote)
+
+    logger.info('--filtering ticker data')
+
+
+
+
+

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -13,6 +13,7 @@ import prosper.datareader.coins.info as info
 LOGGER = config.LOGGER
 HERE = path.abspath(path.dirname(__file__))
 
+__all__ = ('get_orderbook_hitbtc', 'get_quote_hitbtc')
 class OrderBook(Enum):
     """enumerator for handling order book info"""
     asks = 'asks'

--- a/prosper/datareader/coins/prices.py
+++ b/prosper/datareader/coins/prices.py
@@ -1,7 +1,7 @@
 """datareader.coins.prices.py: tools for fetching cryptocoin price data"""
 from datetime import datetime
-import itertools
 from os import path
+from enum import Enum
 
 import requests
 import pandas as pd
@@ -11,6 +11,11 @@ import prosper.datareader.exceptions as exceptions
 
 LOGGER = G_LOGGER
 HERE = path.abspath(path.dirname(__file__))
+
+class OrderBook(Enum):
+    """enumerator for handling order book info"""
+    asks = 'asks'
+    bids = 'bids'
 
 def _listify(
         data,
@@ -35,7 +40,7 @@ def _listify(
     return listified_data
 
 COIN_TICKER_URI = 'http://api.hitbtc.com/api/1/public/{symbol}/ticker'
-def get_ticker(
+def get_ticker_hitbtc(
         symbol,
         uri=COIN_TICKER_URI
 ):
@@ -49,7 +54,7 @@ def get_ticker(
         uri (str, optional): resource link
 
     Returns:
-        (:obj:`dict`): ticker data for desired coin
+        (:obj:`dict`) or (:obj:`list`): ticker data for desired coin
 
     """
     full_uri = ''
@@ -66,3 +71,40 @@ def get_ticker(
         data = _listify(data, 'symbol')
 
     return data
+
+COIN_ORDER_BOOK_URI = 'http://api.hitbtc.com/api/1/public/{symbol}/orderbook'
+def get_order_book_hitbtc(
+        symbol,
+        format_price='number',
+        format_amount='number',
+        uri=COIN_ORDER_BOOK_URI
+):
+    """fetch orderbook data
+
+    Notes:
+        incurs a .format(ticker=symbol) call, be careful with overriding uri
+
+    Args:
+        symbol (str): name of coin-ticker to pull
+        format_price (str, optional): optional format helper
+        format_amount (str, optional): optional format helper
+        uri (str, optional): resource link
+
+    Returns:
+        (:obj:`dict`): order book for coin-ticker
+
+    """
+    params = {}
+    #TODO: this sucks
+    if format_price:
+        params['format_price'] = format_price
+    if format_amount:
+        params['format_amount'] = format_amount
+
+    full_uri = uri.format(symbol=symbol)
+    req = requests.get(full_uri, params=params)
+    req.raise_for_status()
+
+    data = req.json()
+
+    return data #return both bids/asks for other steps to clean up later

--- a/prosper/datareader/config.py
+++ b/prosper/datareader/config.py
@@ -1,3 +1,20 @@
 import prosper.common.prosper_logging as p_logging
 
 LOGGER = p_logging.DEFAULT_LOGGER
+
+def _list_to_str(ticker_list):
+    """parses/joins ticker list
+
+    Args:
+        ticker_list (:obj:`list` or str): ticker(s) to parse
+
+    Returns:
+        (str): list of tickers
+
+    """
+    if isinstance(ticker_list, str):
+        return ticker_list.upper()
+    elif isinstance(ticker_list, list):
+        return ','.join(ticker_list).upper()
+    else:
+        raise TypeError

--- a/prosper/datareader/exceptions.py
+++ b/prosper/datareader/exceptions.py
@@ -32,3 +32,13 @@ class StocksPricesException(StocksException):
 class StocksNewsException(StocksException):
     """base class for Datareader.stocks.prices"""
     pass
+
+###########
+## Coins ##
+###########
+class CoinsException(DatareaderException):
+    """base class for Datareader.coins"""
+    pass
+class SymbolNotSupported(CoinsException):
+    """symbol not supported by API source"""
+    pass

--- a/prosper/datareader/exceptions.py
+++ b/prosper/datareader/exceptions.py
@@ -42,3 +42,6 @@ class CoinsException(DatareaderException):
 class SymbolNotSupported(CoinsException):
     """symbol not supported by API source"""
     pass
+class TickerNotFound(CoinsException):
+    """unable to find more information about requested ticker"""
+    pass

--- a/prosper/datareader/stocks/prices.py
+++ b/prosper/datareader/stocks/prices.py
@@ -9,27 +9,11 @@ import dateutil.parser
 import requests
 import pandas as pd
 
-from prosper.datareader.config import LOGGER as G_LOGGER
+import prosper.datareader.config as config
 
-LOGGER = G_LOGGER
+LOGGER = config.LOGGER
 HERE = path.abspath(path.dirname(__file__))
 
-def ticker_list_to_str(ticker_list):
-    """parses/joins ticker list
-
-    Args:
-        ticker_list (:obj:`list` or str): ticker(s) to parse
-
-    Returns:
-        (str): list of tickers
-
-    """
-    if isinstance(ticker_list, str):
-        return ticker_list.upper()
-    elif isinstance(ticker_list, list):
-        return ','.join(ticker_list).upper()
-    else:
-        raise TypeError
 
 def cast_str_to_int(dataframe):
     """tries to apply to_numeric to each str column
@@ -70,7 +54,7 @@ def fetch_price_quotes_rh(
         (:obj:`list`): results from endpoint, JSONable
 
     """
-    ticker_list_str = ticker_list_to_str(ticker_list)
+    ticker_list_str = config._list_to_str(ticker_list)
     logger.info('fetching quote data for %s -- Robinhood', ticker_list_str)
 
     params = {
@@ -202,7 +186,7 @@ def get_quote_rh(
         {'ticker', 'company_name', 'price', 'percent_change', 'PE', 'short_ratio', 'quote_datetime'}
 
     """
-    logger.info('Generating quote for %s -- Robinhood', ticker_list_to_str(ticker_list))
+    logger.info('Generating quote for %s -- Robinhood', config._list_to_str(ticker_list))
 
     ## Gather Required Data ##
     summary_raw_data = []

--- a/prosper/datareader/utils.py
+++ b/prosper/datareader/utils.py
@@ -9,11 +9,14 @@ try:
 except ImportError: #pragma: no cover
     NLTK_IMPORT = False
 import pandas as pd
+import tinydb
 
 from prosper.datareader.config import LOGGER as G_LOGGER
 import prosper.datareader.exceptions as exceptions
 
+HERE = path.abspath(path.dirname(__file__))
 _TESTMODE = False
+
 INSTALLED_PACKAGES = []
 def _validate_install(
         package_name,
@@ -154,3 +157,20 @@ def vader_sentiment(
     )
 
     return joined_df
+
+def check_cache(
+        cache_name,
+        cache_age=3600,
+        cache_filepath=HERE,
+        logger=G_LOGGER
+):
+    pass
+
+def write_cache(
+        cache_name,
+        cache_filepath=HERE,
+        logger=G_LOGGER
+):
+    pass
+
+

--- a/prosper/datareader/utils.py
+++ b/prosper/datareader/utils.py
@@ -156,20 +156,3 @@ def vader_sentiment(
     )
 
     return joined_df
-
-def check_cache(
-        cache_name,
-        cache_age=3600,
-        cache_filepath=HERE,
-        logger=G_LOGGER
-):
-    pass
-
-def write_cache(
-        cache_name,
-        cache_filepath=HERE,
-        logger=G_LOGGER
-):
-    pass
-
-

--- a/prosper/datareader/utils.py
+++ b/prosper/datareader/utils.py
@@ -9,7 +9,6 @@ try:
 except ImportError: #pragma: no cover
     NLTK_IMPORT = False
 import pandas as pd
-import tinydb
 
 from prosper.datareader.config import LOGGER as G_LOGGER
 import prosper.datareader.exceptions as exceptions

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,8 @@ setup(
     packages=hack_find_packages('prosper'),
     include_package_data=True,
     package_data={
-        '': ['LICENSE', 'README.rst']
+        '': ['LICENSE', 'README.rst'],
+        'prosper': ['datareader/version.txt']
     },
     install_requires=[
         'prospercommon',

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,8 @@ setup(
         'six',
         'semantic-version',
         'demjson~=2.2.4',
-        'ujson~=1.35'
+        'ujson~=1.35',
+        'tinydb~=3.4.1'
     ],
     tests_require=[
         'jsonschema',

--- a/setup.py
+++ b/setup.py
@@ -138,9 +138,7 @@ setup(
         'requests',
         'six',
         'semantic-version',
-        'demjson~=2.2.4',
-        'ujson~=1.35',
-        'tinydb~=3.4.1'
+        'demjson~=2.2.4'
     ],
     tests_require=[
         'jsonschema',

--- a/tests/schemas/coins/hitbtc_orderbook.schema
+++ b/tests/schemas/coins/hitbtc_orderbook.schema
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "properties":{
+        "asks":{
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type":"number"
+                }
+            }
+        },
+        "bids":{
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type":"number"
+                }
+            }
+        }
+    },
+    "required": ["asks", "bids"],
+    "additionalProperties": false
+}

--- a/tests/schemas/coins/hitbtc_symbols.schema
+++ b/tests/schemas/coins/hitbtc_symbols.schema
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "properties":{
+        "symbol": {"type":"string", "pattern":"([A-Z])+"},
+        "step": {"type":"string"},
+        "lot": {"type":"string"},
+        "currency": {"type":"string", "pattern":"([A-Z])+"},
+        "commodity": {"type":"string", "pattern":"([A-Z])+"},
+        "takeLiquidityRate": {"type":"string"},
+        "provideLiquidityRate": {"type":"string"}
+    },
+    "required": ["symbol", "currency", "commodity"],
+    "additionalProperties": false
+}

--- a/tests/schemas/coins/hitbtc_ticker.schema
+++ b/tests/schemas/coins/hitbtc_ticker.schema
@@ -1,0 +1,19 @@
+{
+	"type": "object",
+	"properties":{
+		"ask": {"type":"string"},
+		"bid": {"type":"string"},
+		"last": {"type":"string"},
+		"low": {"type":"string"},
+		"high": {"type":"string"},
+		"open": {"type":"string"},
+		"volume": {"type":"string"},
+		"volume_quote": {"type":"string"},
+		"timestamp": {"type":"integer"}
+	},
+	"required": [
+		"ask", "bid", "last", "low", "high", "open", "volume", 
+		"volume_quote", "timestamp"
+	],
+	"additionalProperties": false
+}

--- a/tests/schemas/coins/hitbtc_ticker.schema
+++ b/tests/schemas/coins/hitbtc_ticker.schema
@@ -9,7 +9,8 @@
 		"open": {"type":"string"},
 		"volume": {"type":"string"},
 		"volume_quote": {"type":"string"},
-		"timestamp": {"type":"integer"}
+		"timestamp": {"type":"integer"},
+		"symbol": {"type":"string"}
 	},
 	"required": [
 		"ask", "bid", "last", "low", "high", "open", "volume", 

--- a/tests/schemas/stocks/rh_news.schema
+++ b/tests/schemas/stocks/rh_news.schema
@@ -11,7 +11,7 @@
         "updated_at": {"type":"string"},
         "instrument": {"type":"string", "format":"uri"},
         "num_clicks": {"type":"integer"},
-        "uuid": {"type":"null"},
+        "uuid": {"type":["string", "null"]},
         "relay_url": {"type":"string", "format":"date-time"},
         "preview_image_url": {"type":"string"}
     },

--- a/tests/schemas/stocks/rh_news.schema
+++ b/tests/schemas/stocks/rh_news.schema
@@ -11,11 +11,13 @@
         "updated_at": {"type":"string"},
         "instrument": {"type":"string", "format":"uri"},
         "num_clicks": {"type":"integer"},
-        "uuid": {"type":"null"}
+        "uuid": {"type":"null"},
+        "relay_url": {"type":"string", "format":"date-time"},
+        "preview_image_url": {"type":"string"}
     },
     "requires": [
         "url", "title", "source", "published_at", "author", 
         "summary", "api_source", "updated_at", "instrument", 
-        "num_clicks", "uuid"],
+        "num_clicks", "uuid", "relay_url", "preview_image_url"],
     "additionalProperties": false
 }

--- a/tests/test_coins_info.py
+++ b/tests/test_coins_info.py
@@ -20,11 +20,11 @@ def test_get_supported_symbols_hitbtc():
             path.join('coins', 'hitbtc_symbols.schema')
         )
 
-class TestSupportedCommodity:
-    """tests for info.supported_commodity()"""
-    def test_supported_commodities_nocache(self):
-        """validate supported_commodity() happypath"""
-        commodity_list = info.supported_commodities(force_refresh=True)
+class TestSupportedSymbolInfo:
+    """validate supported_symbol_info() behavior"""
+    def test_supported_commodities(self):
+        """validate commoddity list"""
+        commodity_list = info.supported_symbol_info('commodity')
 
         assert isinstance(commodity_list, list)
 
@@ -42,27 +42,33 @@ class TestSupportedCommodity:
             'QAU', 'MANA', 'DNT', 'FYP', 'OPT', 'GRPH', 'TNT', 'STX', 'CAT', 'BCC',
             'ECAT', 'BAS', 'ZRX', 'RVT', 'ICOS', 'PPC', 'VERI', 'IGNIS', 'QTUM',
             'PRG', 'BMC', 'CND', 'ANT', 'EMGO', 'SKIN', 'FUN', 'HVN', 'AMB', 'CDT',
-            'AIR', 'POE'
+            'AIR', 'POE', 'FUEL', 'MCAP'
         ]
         unique_commodities = list(set(commodity_list) - set(expected_commodities))
         missing_commodities = list(set(expected_commodities) - set(commodity_list))
-        print('unique_commodities={}'.format(unique_commodities))
         print('missing_commodities={}'.format(missing_commodities))
 
-        assert unique_commodities == []
         assert missing_commodities == []
-    #TODO: CACHE TESTS
+        if unique_commodities:
+            pytest.xfail('unique_commodities={}'.format(unique_commodities))
 
-class TestSupportedCurrencies:
-    """tests for info.supported_currencies()"""
-    def test_supported_currencies_nocache(self):
-        """validate supported_currencies() happypath"""
-        currency_list = info.supported_currencies(force_refresh=True)
+    def test_supported_currencies(self):
+        """validate currency list"""
+        currency_list = info.supported_symbol_info('currency')
 
         assert isinstance(currency_list, list)
 
         expected_currencies = ['BTC', 'EUR', 'USD', 'ETH']
         assert currency_list == expected_currencies
+
+    def test_supported_symbols(self):
+        """validate symbols list"""
+        symbols_list = info.supported_symbol_info('symbol')
+
+        assert isinstance(symbols_list, list)
+
+        #TODO: validate values?
+
 
 class TestGetSymbol:
     """tests for info.get_symbol()"""

--- a/tests/test_coins_info.py
+++ b/tests/test_coins_info.py
@@ -90,3 +90,24 @@ class TestGetSymbol:
                 'BUTTS',
                 force_refresh=True #TODO: remove
             )
+
+class TestGetTickerInfo:
+    """tests info.get_ticker_info()"""
+    good_symbol = 'BTCUSD'
+
+    def test_get_ticker_info_happypath_nocache(self):
+        """validate expected behavior for get_ticker_info()"""
+        symbol_info = info.get_ticker_info(
+            self.good_symbol,
+            force_refresh=True
+        )
+        assert symbol_info['symbol'] == self.good_symbol
+        assert symbol_info['currency'] == 'USD'
+
+    def test_get_ticker_info_bad_symbol(self):
+        """validate exception case when bad symbol inputs requested"""
+        with pytest.raises(exceptions.TickerNotFound):
+            bad_symbol = info.get_ticker_info(
+                'BUTTS',
+                force_refresh=True #TODO: remove
+            )

--- a/tests/test_coins_info.py
+++ b/tests/test_coins_info.py
@@ -78,11 +78,7 @@ class TestGetSymbol:
 
     def test_get_symbol_happypath_nocache(self):
         """validate expected behavior for get_symbol()"""
-        symbol = info.get_symbol(
-            self.good_commodity,
-            self.good_currency,
-            force_refresh=True
-        )
+        symbol = info.get_symbol(self.good_commodity, self.good_currency)
 
         assert isinstance(symbol, str)
         assert symbol == self.good_symbol
@@ -90,18 +86,10 @@ class TestGetSymbol:
     def test_get_symbol_bad_symbol(self):
         """validate exception case when bad symbol inputs requested"""
         with pytest.raises(exceptions.SymbolNotSupported):
-            bad_symbol = info.get_symbol(
-                'BUTTS',
-                self.good_currency,
-                force_refresh=True #TODO: remove
-            )
+            bad_symbol = info.get_symbol('BUTTS', self.good_currency)
 
         with pytest.raises(exceptions.SymbolNotSupported):
-            bad_symbol = info.get_symbol(
-                self.good_commodity,
-                'BUTTS',
-                force_refresh=True #TODO: remove
-            )
+            bad_symbol = info.get_symbol(self.good_commodity, 'BUTTS')
 
 class TestGetTickerInfo:
     """tests info.get_ticker_info()"""
@@ -109,17 +97,11 @@ class TestGetTickerInfo:
 
     def test_get_ticker_info_happypath_nocache(self):
         """validate expected behavior for get_ticker_info()"""
-        symbol_info = info.get_ticker_info(
-            self.good_symbol,
-            force_refresh=True
-        )
+        symbol_info = info.get_ticker_info(self.good_symbol)
         assert symbol_info['symbol'] == self.good_symbol
         assert symbol_info['currency'] == 'USD'
 
     def test_get_ticker_info_bad_symbol(self):
         """validate exception case when bad symbol inputs requested"""
         with pytest.raises(exceptions.TickerNotFound):
-            bad_symbol = info.get_ticker_info(
-                'BUTTS',
-                force_refresh=True #TODO: remove
-            )
+            bad_symbol = info.get_ticker_info('BUTTS')

--- a/tests/test_coins_info.py
+++ b/tests/test_coins_info.py
@@ -1,4 +1,4 @@
-"""test_stocks_news.py: validate behavior for datareader.stocks.news"""
+"""test_coins_info.py: validate behavior for datareader.coins.info"""
 from datetime import datetime
 from os import path
 
@@ -10,9 +10,9 @@ import pandas
 import prosper.datareader.coins.info as info
 import prosper.datareader.exceptions as exceptions
 
-def test_get_supported_symbols():
-    """validate get_supported_symbols() returns valid schema"""
-    data = info.get_supported_symbols()
+def test_get_supported_symbols_hitbtc():
+    """validate get_supported_symbols_hitbtc() returns valid schema"""
+    data = info.get_supported_symbols_hitbtc()
 
     for symbol in data:
         helpers.validate_schema(
@@ -41,10 +41,16 @@ class TestSupportedCommodity:
             'AVT', 'TFL', 'COSS', 'PBKX', 'PQT', '8BT', 'EVX', 'IML', 'ROOTS', 'DELTA',
             'QAU', 'MANA', 'DNT', 'FYP', 'OPT', 'GRPH', 'TNT', 'STX', 'CAT', 'BCC',
             'ECAT', 'BAS', 'ZRX', 'RVT', 'ICOS', 'PPC', 'VERI', 'IGNIS', 'QTUM',
-            'PRG', 'BMC', 'CND', 'ANT', 'EMGO', 'SKIN'
+            'PRG', 'BMC', 'CND', 'ANT', 'EMGO', 'SKIN', 'FUN', 'HVN', 'AMB', 'CDT',
+            'AIR', 'POE'
         ]
-        assert commodity_list == expected_commodities
+        unique_commodities = list(set(commodity_list) - set(expected_commodities))
+        missing_commodities = list(set(expected_commodities) - set(commodity_list))
+        print('unique_commodities={}'.format(unique_commodities))
+        print('missing_commodities={}'.format(missing_commodities))
 
+        assert unique_commodities == []
+        assert missing_commodities == []
     #TODO: CACHE TESTS
 
 class TestSupportedCurrencies:

--- a/tests/test_coins_info.py
+++ b/tests/test_coins_info.py
@@ -1,0 +1,92 @@
+"""test_stocks_news.py: validate behavior for datareader.stocks.news"""
+from datetime import datetime
+from os import path
+
+import pytest
+import requests
+import helpers
+import pandas
+
+import prosper.datareader.coins.info as info
+import prosper.datareader.exceptions as exceptions
+
+def test_get_supported_symbols():
+    """validate get_supported_symbols() returns valid schema"""
+    data = info.get_supported_symbols()
+
+    for symbol in data:
+        helpers.validate_schema(
+            symbol,
+            path.join('coins', 'hitbtc_symbols.schema')
+        )
+
+class TestSupportedCommodity:
+    """tests for info.supported_commodity()"""
+    def test_supported_commodities_nocache(self):
+        """validate supported_commodity() happypath"""
+        commodity_list = info.supported_commodities(force_refresh=True)
+
+        assert isinstance(commodity_list, list)
+
+        expected_commodities = [
+            'BCN', 'BTC', 'DASH', 'DOGE', 'DSH', 'EMC', 'ETH', 'FCN', 'LSK', 'LTC',
+            'NXT', 'QCN', 'SBD', 'SC', 'STEEM', 'XDN', 'XEM', 'XMR', 'ARDR', 'ZEC',
+            'WAVES', 'MAID', 'AMP', 'BUS', 'DGD', 'ICN', 'SNGLS', '1ST', 'XLC', 'TRST',
+            'TIME', 'GNO', 'REP', 'ZRC', 'BOS', 'DCT', 'AEON', 'GUP', 'PLU', 'LUN',
+            'TAAS', 'NXC', 'EDG', 'RLC', 'SWT', 'TKN', 'WINGS', 'XAUR', 'AE', 'PTOY',
+            'WTT', 'ETC', 'CFI', 'PLBT', 'BNT', 'XDNCO', 'FYN', 'SNM', 'SNT', 'CVC',
+            'PAY', 'OAX', 'OMG', 'BQX', 'XTZ', 'CRS', 'DICE', 'XRP', 'MPK', 'NET',
+            'STRAT', 'SNC', 'ADX', 'BET', 'EOS', 'DENT', 'SAN', 'MNE', 'MRV', 'MSP',
+            'DDF', 'UET', 'MYB', 'SUR', 'IXT', 'HRB', 'PLR', 'TIX', 'NDC', 'PRO',
+            'AVT', 'TFL', 'COSS', 'PBKX', 'PQT', '8BT', 'EVX', 'IML', 'ROOTS', 'DELTA',
+            'QAU', 'MANA', 'DNT', 'FYP', 'OPT', 'GRPH', 'TNT', 'STX', 'CAT', 'BCC',
+            'ECAT', 'BAS', 'ZRX', 'RVT', 'ICOS', 'PPC', 'VERI', 'IGNIS', 'QTUM',
+            'PRG', 'BMC', 'CND', 'ANT', 'EMGO', 'SKIN'
+        ]
+        assert commodity_list == expected_commodities
+
+    #TODO: CACHE TESTS
+
+class TestSupportedCurrencies:
+    """tests for info.supported_currencies()"""
+    def test_supported_currencies_nocache(self):
+        """validate supported_currencies() happypath"""
+        currency_list = info.supported_currencies(force_refresh=True)
+
+        assert isinstance(currency_list, list)
+
+        expected_currencies = ['BTC', 'EUR', 'USD', 'ETH']
+        assert currency_list == expected_currencies
+
+class TestGetSymbol:
+    """tests for info.get_symbol()"""
+    good_commodity = 'BTC'
+    good_currency = 'USD'
+    good_symbol = 'BTCUSD'
+
+    def test_get_symbol_happypath_nocache(self):
+        """validate expected behavior for get_symbol()"""
+        symbol = info.get_symbol(
+            self.good_commodity,
+            self.good_currency,
+            force_refresh=True
+        )
+
+        assert isinstance(symbol, str)
+        assert symbol == self.good_symbol
+
+    def test_get_symbol_bad_symbol(self):
+        """validate exception case when bad symbol inputs requested"""
+        with pytest.raises(exceptions.SymbolNotSupported):
+            bad_symbol = info.get_symbol(
+                'BUTTS',
+                self.good_currency,
+                force_refresh=True #TODO: remove
+            )
+
+        with pytest.raises(exceptions.SymbolNotSupported):
+            bad_symbol = info.get_symbol(
+                self.good_commodity,
+                'BUTTS',
+                force_refresh=True #TODO: remove
+            )

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -10,6 +10,24 @@ import pandas
 import prosper.datareader.coins.prices as prices
 import prosper.datareader.exceptions as exceptions
 
+def test_listify():
+    """validate expected behavior for _listify()"""
+    demo_data = {
+        'key1': {
+            'val1': 1,
+            'val2': 2
+        },
+        'key2': {
+            'val1': 10,
+            'val2': 20
+        }
+    }
+    fixed_data = prices._listify(demo_data, 'key')
+    assert isinstance(fixed_data, list)
+    expected_keys = ['val1', 'val2', 'key']
+    for row in fixed_data:
+        assert list(row.keys()) == expected_keys
+
 def test_get_ticker_single():
     """validate get_ticker() returns valid schema"""
     data = prices.get_ticker('BTCUSD')

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -29,8 +29,8 @@ def test_listify():
         assert list(row.keys()) == expected_keys
 
 def test_get_ticker_single():
-    """validate get_ticker() returns valid schema"""
-    data = prices.get_ticker('BTCUSD')
+    """validate get_ticker_hitbtc() returns valid schema"""
+    data = prices.get_ticker_hitbtc('BTCUSD')
 
     assert isinstance(data, dict)
     helpers.validate_schema(
@@ -39,11 +39,11 @@ def test_get_ticker_single():
     )
 
     with pytest.raises(requests.exceptions.HTTPError):
-        bad_data = prices.get_ticker('BUTTS')
+        bad_data = prices.get_ticker_hitbtc('BUTTS')
 
 def test_get_ticker_all():
     """validate get_ticker() behavior with blank args"""
-    data = prices.get_ticker('')
+    data = prices.get_ticker_hitbtc('')
 
     assert isinstance(data, list)
     helpers.validate_schema(
@@ -51,3 +51,11 @@ def test_get_ticker_all():
         path.join('coins', 'hitbtc_ticker.schema')
     )
     assert len(data) >= 190 * 0.9 #expect ~same data or more
+
+def test_get_orderbook():
+    """validate get_order_book_hitbtc() returns valid schema"""
+    data = prices.get_order_book_hitbtc('BTCUSD')
+
+    assert isinstance(data, dict)
+    assert isinstance(data['asks'], list)
+    assert isinstance(data['bids'], list)

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -62,3 +62,16 @@ def test_get_orderbook():
     assert isinstance(data, dict)
     assert isinstance(data['asks'], list)
     assert isinstance(data['bids'], list)
+
+def test_coin_list_to_ticker_list():
+    """validate coin_list_to_ticker_list() works as expected"""
+    test_coin_list = ['BTC', 'ETH']
+
+    ticker_list = prices.coin_list_to_ticker_list(test_coin_list)
+
+    expected_tickers = ['BTCUSD', 'ETHUSD']
+    assert isinstance(ticker_list, list)
+    assert ticker_list == expected_tickers
+
+    with pytest.raises(KeyError):
+        bad_ticker = prices.coin_list_to_ticker_list(['BUTTS'], strict=True)

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -1,0 +1,23 @@
+"""test_coins_prices.py: validate behavior for datareader.coins.prices"""
+from datetime import datetime
+from os import path
+
+import pytest
+import requests
+import helpers
+import pandas
+
+import prosper.datareader.coins.prices as prices
+import prosper.datareader.exceptions as exceptions
+
+def test_get_ticker():
+    """validate get_ticker() returns valid schema"""
+    data = prices.get_ticker('BTCUSD')
+
+    helpers.validate_schema(
+        data,
+        path.join('coins', 'hitbtc_ticker.schema')
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        bad_data = prices.get_ticker('BUTTS')

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -75,3 +75,37 @@ def test_coin_list_to_ticker_list():
 
     with pytest.raises(KeyError):
         bad_ticker = prices.coin_list_to_ticker_list(['BUTTS'], strict=True)
+
+class TestGetQuoteHitBTC:
+    """validate get_quote_hitbtc() behavior"""
+    coin_list = ['BTC', 'ETH']
+    bad_list = ['BUTTS']
+    expected_headers = [
+        'ask', 'bid', 'high', 'last', 'low', 'open', 'symbol',
+        'timestamp', 'volume', 'volume_quote'
+    ]
+
+    def test_get_quote_hitbtc_happypath(self):
+        """validate expected normal behavior"""
+        quote = prices.get_quote_hitbtc(self.coin_list)
+
+        assert isinstance(quote, pandas.DataFrame)
+
+        print(list(quote.columns.values))
+        assert list(quote.columns.values) == self.expected_headers
+        assert len(quote) == len(self.coin_list)
+
+    def test_get_quote_hitbtc_error(self):
+        """validate system throws as expected"""
+        with pytest.raises(KeyError):
+            bad_quote = prices.get_quote_hitbtc(self.bad_list)
+
+    def test_get_quote_hitbtc_singleton(self):
+        """validate quote special case for 1 value"""
+        quote = prices.get_quote_hitbtc([self.coin_list[0]])
+
+        assert isinstance(quote, pandas.DataFrame)
+
+        print(list(quote.columns.values))
+        assert list(quote.columns.values) == self.expected_headers
+        assert len(quote) == 1

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -25,8 +25,11 @@ def test_listify():
     fixed_data = prices._listify(demo_data, 'key')
     assert isinstance(fixed_data, list)
     expected_keys = ['val1', 'val2', 'key']
+    expected_keys.sort()
     for row in fixed_data:
-        assert list(row.keys()) == expected_keys
+        keys = list(row.keys())
+        keys.sort()
+        assert keys == expected_keys
 
 def test_get_ticker_single():
     """validate get_ticker_hitbtc() returns valid schema"""

--- a/tests/test_coins_prices.py
+++ b/tests/test_coins_prices.py
@@ -10,10 +10,11 @@ import pandas
 import prosper.datareader.coins.prices as prices
 import prosper.datareader.exceptions as exceptions
 
-def test_get_ticker():
+def test_get_ticker_single():
     """validate get_ticker() returns valid schema"""
     data = prices.get_ticker('BTCUSD')
 
+    assert isinstance(data, dict)
     helpers.validate_schema(
         data,
         path.join('coins', 'hitbtc_ticker.schema')
@@ -21,3 +22,14 @@ def test_get_ticker():
 
     with pytest.raises(requests.exceptions.HTTPError):
         bad_data = prices.get_ticker('BUTTS')
+
+def test_get_ticker_all():
+    """validate get_ticker() behavior with blank args"""
+    data = prices.get_ticker('')
+
+    assert isinstance(data, list)
+    helpers.validate_schema(
+        data[0],
+        path.join('coins', 'hitbtc_ticker.schema')
+    )
+    assert len(data) >= 190 * 0.9 #expect ~same data or more

--- a/tests/test_stocks_news.py
+++ b/tests/test_stocks_news.py
@@ -178,8 +178,9 @@ class TestCompanyNewsRobinhood:
     good_ticker = helpers.CONFIG.get('STOCKS', 'good_ticker')
     bad_ticker = helpers.CONFIG.get('STOCKS', 'bad_ticker')
     expected_news_cols = [
-        'api_source', 'author', 'instrument', 'num_clicks', 'published_at',
-        'source', 'summary', 'title', 'updated_at', 'url', 'uuid'
+        'api_source', 'author', 'instrument', 'num_clicks', 'preview_image_url',
+        'published_at', 'relay_url', 'source', 'summary', 'title', 'updated_at',
+        'url', 'uuid'
     ]
 
     @pytest.mark.long
@@ -242,4 +243,5 @@ class TestCompanyNewsRobinhood:
         expected_cols = self.expected_news_cols
         expected_cols.extend(['neu', 'pos', 'compound', 'neg'])
 
+        print(list(graded_news.columns.values))
         assert list(graded_news.columns.values) == expected_cols

--- a/tests/test_stocks_prices.py
+++ b/tests/test_stocks_prices.py
@@ -11,6 +11,7 @@ import numpy
 
 import prosper.datareader.stocks.prices as prices
 import prosper.datareader.exceptions as exceptions
+import prosper.datareader.config as config
 
 class TestExpectedSchemas:
     good_ticker = helpers.CONFIG.get('STOCKS', 'good_ticker')
@@ -68,24 +69,24 @@ def test_ticker_list_to_str():
     """make sure ticker_list_to_str returns as expected"""
     no_caps_pattern = re.compile('[a-z]+')
 
-    single_stock = prices.ticker_list_to_str('MU')
+    single_stock = config._list_to_str('MU')
     assert not no_caps_pattern.match(single_stock)
     assert single_stock == 'MU'
 
-    lower_stock = prices.ticker_list_to_str('mu')
+    lower_stock = config._list_to_str('mu')
     assert not no_caps_pattern.match(lower_stock)
     assert lower_stock == 'MU'
 
-    multi_stock = prices.ticker_list_to_str(['MU', 'INTC', 'BA'])
+    multi_stock = config._list_to_str(['MU', 'INTC', 'BA'])
     assert not no_caps_pattern.match(multi_stock)
     assert multi_stock == 'MU,INTC,BA'
 
-    lower_multi_stock = prices.ticker_list_to_str(['MU', 'intc', 'BA'])
+    lower_multi_stock = config._list_to_str(['MU', 'intc', 'BA'])
     assert not no_caps_pattern.match(lower_multi_stock)
     assert lower_multi_stock == 'MU,INTC,BA'
 
     with pytest.raises(TypeError):
-        bad_stock = prices.ticker_list_to_str({'butts':1})
+        bad_stock = config._list_to_str({'butts':1})
 
 def test_cast_str_to_int():
     """validate behavior for cast_str_to_int"""


### PR DESCRIPTION
Using [hitBTC](https://hitbtc.com/api) add support for looking at crypto currencies

* Adds `.coins` subgroup
* Adds support for
    * Finding `tickers`: coin + currency _FOREX_ style lookup keys
    * Reverse-lookup from coin->ticker
    * Generate quote data: OHLC, current price, %change
    * Look at the current orderbook for a given coin
* Updates docs for new feeds
* Sweet Sweet Test Coverage
    * Removed `3.7-dev` from travis plan.  Pandas vs 3.7 is causing more noise than signal 