### PR TITLE
Add login helper and update quotes API

### DIFF
--- a/prosper/datareader/robinhood/__init__.py
+++ b/prosper/datareader/robinhood/__init__.py
@@ -1,2 +1,3 @@
 from . import quotes
 from . import news
+from . import auth

--- a/prosper/datareader/robinhood/auth.py
+++ b/prosper/datareader/robinhood/auth.py
@@ -1,0 +1,69 @@
+"""Helper for logging in/out of Robinhood"""
+import logging
+
+import requests
+
+RH_LOGIN = ''
+RH_LOGOUT = ''
+class RobinHoodAuth(object):
+    """context manager for logging in and out of Robinhood
+
+    Args:
+        username (str): Robinhood username
+        password (str): Robinhood password
+        client_id (str): oAuth client header
+
+    Note:
+        Does not work with `mfa_code` or 2-FA accounts
+
+    Returns:
+        str: bearer token for authenticating requests
+
+    Raises:
+        requests.RequestException: connection or HTTP errors
+        KeyError: expected json response missing required keys
+
+    """
+    def __init__(
+            self,
+            username,
+            password,
+            client_id='c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS'
+    ):
+        self._username = username
+        self._password = password
+        self.client_id = client_id
+
+        self.bearer_token = ''
+        self.refresh_token = ''
+
+    def __enter__(self):
+        """context manager for logging in.  Returns bearer_token for use elsewhere"""
+        logging.debug('RobinHood LOGIN -- `%s` with `%s`', RH_LOGIN, self._username)
+        req = requests.post(
+            RH_LOGIN,
+            data=dict(
+                password=self._password,
+                username=self._username,
+                grant_type='password',
+                client_id=self.client_id,
+            )
+        )
+        req.raise_for_status()
+        self.bearer_token = 'Bearer ' + req.json()['access_token']
+        self.refresh_token = req.json()['refresh_token']
+        logging.info('RobinHood LOGIN -- Success')
+        return self.bearer_token
+
+    def __exit__(self, *exc_info):
+        logging.debug('RobinHood LOGOUT -- `%s` with `%s`', RH_LOGOUT, self._username)
+        req = requests.post(
+            RH_LOGOUT,
+            data=dict(
+                client_id=self.client_id,
+                token=self.refresh_token,
+            )
+        )
+        req.raise_for_status()
+        self.bearer_token = ''
+        self.refresh_token = ''

--- a/prosper/datareader/robinhood/auth.py
+++ b/prosper/datareader/robinhood/auth.py
@@ -3,8 +3,8 @@ import logging
 
 import requests
 
-RH_LOGIN = ''
-RH_LOGOUT = ''
+RH_LOGIN = 'https://api.robinhood.com/oauth2/token/'
+RH_LOGOUT = 'https://api.robinhood.com/oauth2/revoke_token/'
 class RobinHoodAuth(object):
     """context manager for logging in and out of Robinhood
 

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ class PyTest(TestCommand):
         self.pytest_args = [
             'tests',
             '-rx',
+            '-m new',  # !! FIXME: REMOVE ME !!
             '-vv',
             '--cov=prosper/' + __library_name__,
             '--cov-report=term-missing',
@@ -152,6 +153,7 @@ setup(
         'testfixtures',
         'pytest_cov',
         'pytest-xdist',
+        'nltk',
     ],
     extras_require={
         'dev':[

--- a/tests/schemas/stocks/rh_user.schema
+++ b/tests/schemas/stocks/rh_user.schema
@@ -1,0 +1,12 @@
+{
+    "type": "object",
+    "properties": {
+        "url": {"type": "string", "format": "uri"},
+        "username": {"type": "string"},
+        "id": {"type": "string"}
+    },
+    "required": [
+        "url", "username", "id"
+    ],
+    "additionalProperties": false
+}

--- a/tests/test_config.cfg
+++ b/tests/test_config.cfg
@@ -7,6 +7,11 @@
     instruments_url = https://api.robinhood.com/instruments/0a8a072c-e52c-4e41-a2ee-8adbd72217d3/
     instruments_ticker = MU
 
+[ROBINHOOD]
+    username = #SECRET
+    password = #SECRET
+    client_id = #SECRET
+
 [INTRINIO]
     username = #SECRET
     password = #SECRET


### PR DESCRIPTION
Robinhood put the quotes endpoint behind login.  This adds a `contextmanager` to help handle logging in/out of Robinhood services without janking up the API too badly (we hope).